### PR TITLE
fix link to microstructure database in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,4 +33,4 @@ We are just starting this repo and getting input from the community about how it
 * OSU Ocean Mixing Group: <http://mixing.coas.oregonstate.edu/>
 * Guide to GitHub workflow: <https://guides.github.com/introduction/flow/>
 * CVmix: <http://cvmix.github.io/>
-* Amy's Microstructure Database : microstructure.ucsd.edu
+* Amy's Microstructure Database : <http://microstructure.ucsd.edu>


### PR DESCRIPTION
Made the link to microstructure.ucsd.edu clickable - mostly to test the pull request feature.
